### PR TITLE
Fixing unphysical metallicity

### DIFF
--- a/src/physics/infall.c
+++ b/src/physics/infall.c
@@ -69,6 +69,7 @@ void add_infall_to_hot(galaxy_t* central, double infall_mass)
         double strip_mass = -infall_mass;
         // otherwise, strip the mass from the ejected
         if (central->EjectedGas > 0) {
+            double metallicity = calc_metallicity(central->EjectedGas, central->MetalsEjectedGas);
             central->EjectedGas -= strip_mass;
             if (central->EjectedGas < 0) {
                 strip_mass = -central->EjectedGas;
@@ -76,7 +77,7 @@ void add_infall_to_hot(galaxy_t* central, double infall_mass)
                 central->MetalsEjectedGas = 0.0;
             }
             else {
-                central->MetalsEjectedGas -= calc_metallicity(central->EjectedGas, central->MetalsEjectedGas) * strip_mass;
+                central->MetalsEjectedGas -= metallicity * strip_mass;
                 strip_mass = 0.0;
             }
         }
@@ -84,13 +85,14 @@ void add_infall_to_hot(galaxy_t* central, double infall_mass)
         // if we still have mass left to remove after exhausting the mass of
         // the ejected component, the remove as much as we can from the hot gas
         if (strip_mass > 0) {
+            double metallicity = calc_metallicity(central->HotGas, central->MetalsHotGas);
             central->HotGas -= strip_mass;
             if (central->HotGas < 0) {
                 central->HotGas = 0.0;
                 central->MetalsHotGas = 0.0;
             }
             else
-                central->MetalsHotGas -= calc_metallicity(central->HotGas, central->MetalsHotGas) * strip_mass;
+                central->MetalsHotGas -= metallicity * strip_mass;
         }
     }
 }


### PR DESCRIPTION
Calculate the metallicity before subtracting the strip mass. This fix that the metallicity can be greater than 1 in some cases.