### PR TITLE
Include a fix recently added to 21cmFAST

### DIFF
--- a/src/core/ComputeTs.c
+++ b/src/core/ComputeTs.c
@@ -44,6 +44,13 @@ void _ComputeTs(int snapshot)
     double prev_zpp, prev_R, zpp, zp, lower_int_limit_GAL, lower_int_limit_QSO, filling_factor_of_HI_zp, R_factor, R, nuprime, dzp, Luminosity_converstion_factor_GAL, Luminosity_converstion_factor_QSO;
     double collapse_fraction, density_over_mean;
 
+    int n_pts_radii, counter, ii;
+    double trial_zpp_min,trial_zpp_max,trial_zpp, weight;
+    bool first_radii, first_zero;
+    first_radii = true;
+    first_zero = true;
+    n_pts_radii = 1000;
+    
     float curr_xalpha;
     int TsNumFilterSteps = run_globals.params.TsNumFilterSteps;
 
@@ -80,7 +87,7 @@ void _ComputeTs(int snapshot)
     // Remember to add the factor of VOLUME/TOT_NUM_PIXELS when converting from real space to k-space
     // Note: we will leave off factor of VOLUME, in anticipation of the inverse FFT below
     // TODO: Double check that looping over correct number of elements here
-    for (int ii = 0; ii < slab_n_complex; ii++) {
+    for (ii = 0; ii < slab_n_complex; ii++) {
         sfr_unfiltered[ii] /= total_n_cells;
     }
 
@@ -296,6 +303,51 @@ void _ComputeTs(int snapshot)
                 nuprime = nu_n(n_ct)*(1+zpp)/(1.0+zp);
                 sum_lyn[R_ct] += frecycle(n_ct) * spectral_emissivity(nuprime, 0);
             }
+            
+            // Find if we need to add a partial contribution to a radii to avoid kinks in the Lyman-alpha flux
+            // As we look at discrete radii (light-cone redshift, zpp) we can have two radii where one has a
+            // contribution and the next (larger) radii has no contribution. However, if the number of filtering
+            // steps were infinitely large, we would have contributions between these two discrete radii
+            // Thus, this aims to add a weighted contribution to the first radii where this occurs to smooth out
+            // kinks in the average Lyman-alpha flux.
+            
+            // Note: We do not apply this correction to the LW background as it is unaffected by this. It is only
+            // the Lyn contribution that experiences the kink. Applying this correction to LW introduces kinks
+            // into the otherwise smooth quantity
+            if(R_ct > 2 && sum_lyn[R_ct]==0.0 && sum_lyn[R_ct-1]>0. && first_radii) {
+                
+                // The current zpp for which we are getting zero contribution
+                trial_zpp_max = (prev_zpp - (R_values[R_ct] - prev_R)*CMperMPC / drdz(prev_zpp)+prev_zpp)*0.5;
+                // The zpp for the previous radius for which we had a non-zero contribution
+                trial_zpp_min = (zpp_edge[R_ct-2] - (R_values[R_ct-1] - R_values[R_ct-2])*CMperMPC / drdz(zpp_edge[R_ct-2])+zpp_edge[R_ct-2])*0.5;
+                
+                // Split the previous radii and current radii into n_pts_radii smaller radii (redshift) to have fine control of where
+                // it transitions from zero to non-zero
+                // This is a coarse approximation as it assumes that the linear sampling is a good representation of the different
+                // volumes of the shells (from different radii).
+                for(ii=0;ii<n_pts_radii;ii++) {
+                    trial_zpp = trial_zpp_min + (trial_zpp_max - trial_zpp_min)*(float)ii/((float)n_pts_radii-1.);
+                    
+                    counter = 0;
+                    for (n_ct=NSPEC_MAX; n_ct>=2; n_ct--){
+                        if (trial_zpp > zmax(zp, n_ct))
+                            continue;
+                        
+                        counter += 1;
+                    }
+                    if(counter==0&&first_zero) {
+                        first_zero = false;
+                        weight = (float)ii/(float)n_pts_radii;
+                    }
+                }
+                
+                // Now add a non-zero contribution to the previously zero contribution
+                // The amount is the weight, multplied by the contribution from the previous radii
+                sum_lyn[R_ct] = weight * sum_lyn[R_ct-1];
+                first_radii = false;
+            }
+            
+            
         }
 
         growth_factor_zp = dicke(zp);


### PR DESCRIPTION
This includes a fix that was recently added to 21cmFAST. It was found that over successive redshifts there could be kinks in the Lyman-alpha background from the Lyman-n cascade. This was minimised by identifying over which two filtering radii this occurs (one contribution is zero, the other is non-zero) and adding a non-zero contribution to the zero filtering radii. Over successive timesteps the filtering scale over which it was originally zero will build up to the correct amplitude (rather than jumping from zero to non-zero between two successive snapshots).

Does not change things notably, other than smoothing out kink features in the global 21-cm signal.
