### PR TITLE
typo in SN

### DIFF
--- a/src/physics/supernova_feedback.c
+++ b/src/physics/supernova_feedback.c
@@ -162,16 +162,14 @@ static inline double calc_sn_ejection_eff(galaxy_t *gal, int snapshot)
     double SnEjectionRedshiftDep = params->SnEjectionRedshiftDep;
     double SnEjectionEff = params->SnEjectionEff;
     double SnEjectionScaling = params->SnEjectionScaling;
-    double SnEjectionNorm;
+    double SnEjectionNorm = params->SnEjectionNorm;
     switch (SnModel) {
     case 1:    // Guo et al. 2011 with redshift dependence
-        SnEjectionNorm = params->SnEjectionNorm;
         SnEjectionEff *= pow(zplus1/4., SnEjectionRedshiftDep) \
                          *(.5 + pow(Vmax/SnEjectionNorm, -SnEjectionScaling));
         break;
     case 2:
         // Use the same value with that is used for the mass loading
-        SnEjectionNorm = params->SnReheatNorm;
         if (Vmax < SnEjectionNorm)
             SnEjectionScaling = params->SnEjectionScaling2;
         SnEjectionEff *= pow(zplus1/4., SnEjectionRedshiftDep) \


### PR DESCRIPTION
I think it is a typo in case 1 if this is still the Guo+11 model. I also found this parameter actually does not make a significant change to e.g. SMF. But it worths fixing this before tuning the new model.
I also feel that in case 2, even this is supposed to be the same as the mass loading factor, we should use the quantity of SnEjectionNorm and assign the value in the parameter file as the same as the mass loading rather than doing it implicitly in the code.