### PR TITLE
Check to suppress numerical error when integrating

### DIFF
--- a/src/core/ComputeTs.c
+++ b/src/core/ComputeTs.c
@@ -142,11 +142,11 @@ void _ComputeTs(int snapshot)
           i_padded = grid_index(ix, iy, iz, ReionGridDim, INDEX_PADDED);
 
           density_over_mean = 1.0 + run_globals.reion_grids.deltax[i_padded];
-          
+
           if (density_over_mean < REL_TOL) {
-	      density_over_mean = REL_TOL;
-	  }
-          
+            density_over_mean = REL_TOL;
+          }
+
           // Multiplied by h^2 as RtoM(R) uses RhoCrit which doesn't include h factors
           collapse_fraction +=
             run_globals.reion_grids.stars[i_padded] /
@@ -207,11 +207,11 @@ void _ComputeTs(int snapshot)
               }
 
               density_over_mean = 1.0 + run_globals.reion_grids.deltax[i_padded];
-              
+
               if (density_over_mean < REL_TOL) {
-             	  density_over_mean = REL_TOL;
+                density_over_mean = REL_TOL;
               }
-              
+
               collapse_fraction +=
                 run_globals.reion_grids.stars[i_padded] /
                 (RtoM(R) * run_globals.params.Hubble_h * run_globals.params.Hubble_h * density_over_mean) *


### PR DESCRIPTION
The indentation should be correct in this one. This patch fixes an error where the code used to crash while evaluating an integral. Happens only when TOCF grid.dim >= 512 though.